### PR TITLE
chore: bump @modelcontextprotocol/sdk to 1.10.2 and update server usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.10.1",
+        "@modelcontextprotocol/sdk": "1.10.2",
         "@types/node": "22.14.1",
         "node-fetch": "^3.3.2",
         "universal-user-agent": "^7.0.2",
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.1.tgz",
-      "integrity": "sha512-xNYdFdkJqEfIaTVP1gPKoEvluACHZsHZegIoICX8DM1o6Qf3G5u2BQJHmgd0n4YgRPqqK/u1ujQvrgAxxSJT9w==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
+      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "echo 'No tests specified' && exit 0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.10.1",
+    "@modelcontextprotocol/sdk": "1.10.2",
     "@types/node": "22.14.1",
     "node-fetch": "^3.3.2",
     "universal-user-agent": "^7.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import * as actions from './operations/actions.js';
 import {
@@ -23,21 +18,8 @@ import {
 } from './common/errors.js';
 import { VERSION } from "./common/version.js";
 
-const server = new Server(
-  {
-    name: "github-actions-mcp-server",
-    version: VERSION,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  }
-);
-
 function formatGitHubError(error: GitHubError): string {
   let message = `GitHub API Error: ${error.message}`;
-  
   if (error instanceof GitHubValidationError) {
     message = `Validation Error: ${error.message}`;
     if (error.response) {
@@ -58,198 +40,216 @@ function formatGitHubError(error: GitHubError): string {
   } else if (error instanceof GitHubNetworkError) {
     message = `Network Error: ${error.message}\nError code: ${error.errorCode}`;
   }
-
   return message;
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: "list_workflows",
-        description: "List workflows in a GitHub repository",
-        inputSchema: zodToJsonSchema(actions.ListWorkflowsSchema),
-      },
-      {
-        name: "get_workflow",
-        description: "Get details of a specific workflow",
-        inputSchema: zodToJsonSchema(actions.GetWorkflowSchema),
-      },
-      {
-        name: "get_workflow_usage",
-        description: "Get usage statistics of a workflow",
-        inputSchema: zodToJsonSchema(actions.GetWorkflowUsageSchema),
-      },
-      {
-        name: "list_workflow_runs",
-        description: "List all workflow runs for a repository or a specific workflow",
-        inputSchema: zodToJsonSchema(actions.ListWorkflowRunsSchema),
-      },
-      {
-        name: "get_workflow_run",
-        description: "Get details of a specific workflow run",
-        inputSchema: zodToJsonSchema(actions.GetWorkflowRunSchema),
-      },
-      {
-        name: "get_workflow_run_jobs",
-        description: "Get jobs for a specific workflow run",
-        inputSchema: zodToJsonSchema(actions.GetWorkflowRunJobsSchema),
-      },
-      {
-        name: "trigger_workflow",
-        description: "Trigger a workflow run",
-        inputSchema: zodToJsonSchema(actions.TriggerWorkflowSchema),
-      },
-      {
-        name: "cancel_workflow_run",
-        description: "Cancel a workflow run",
-        inputSchema: zodToJsonSchema(actions.CancelWorkflowRunSchema),
-      },
-      {
-        name: "rerun_workflow",
-        description: "Re-run a workflow run",
-        inputSchema: zodToJsonSchema(actions.RerunWorkflowSchema),
-      },
-    ],
-  };
-});
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  try {
-    if (!request.params.arguments) {
-      throw new Error("Arguments are required");
-    }
-
-    switch (request.params.name) {
-      case "list_workflows": {
-        const args = actions.ListWorkflowsSchema.parse(request.params.arguments);
-        const result = await actions.listWorkflows(
-          args.owner,
-          args.repo,
-          args.page,
-          args.perPage
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "get_workflow": {
-        const args = actions.GetWorkflowSchema.parse(request.params.arguments);
-        const result = await actions.getWorkflow(
-          args.owner,
-          args.repo,
-          args.workflowId
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "get_workflow_usage": {
-        const args = actions.GetWorkflowUsageSchema.parse(request.params.arguments);
-        const result = await actions.getWorkflowUsage(
-          args.owner,
-          args.repo,
-          args.workflowId
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "list_workflow_runs": {
-        const args = actions.ListWorkflowRunsSchema.parse(request.params.arguments);
-        const { owner, repo, workflowId, ...options } = args;
-        const result = await actions.listWorkflowRuns(owner, repo, {
-          workflowId,
-          ...options
-        });
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "get_workflow_run": {
-        const args = actions.GetWorkflowRunSchema.parse(request.params.arguments);
-        const result = await actions.getWorkflowRun(
-          args.owner,
-          args.repo,
-          args.runId
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "get_workflow_run_jobs": {
-        const args = actions.GetWorkflowRunJobsSchema.parse(request.params.arguments);
-        const { owner, repo, runId, filter, page, perPage } = args;
-        const result = await actions.getWorkflowRunJobs(
-          owner,
-          repo,
-          runId,
-          filter,
-          page,
-          perPage
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "trigger_workflow": {
-        const args = actions.TriggerWorkflowSchema.parse(request.params.arguments);
-        const { owner, repo, workflowId, ref, inputs } = args;
-        const result = await actions.triggerWorkflow(
-          owner,
-          repo,
-          workflowId,
-          ref,
-          inputs
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "cancel_workflow_run": {
-        const args = actions.CancelWorkflowRunSchema.parse(request.params.arguments);
-        const result = await actions.cancelWorkflowRun(
-          args.owner,
-          args.repo,
-          args.runId
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-      
-      case "rerun_workflow": {
-        const args = actions.RerunWorkflowSchema.parse(request.params.arguments);
-        const result = await actions.rerunWorkflowRun(
-          args.owner,
-          args.repo,
-          args.runId
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      default:
-        throw new Error(`Unknown tool: ${request.params.name}`);
-    }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
-    }
-    if (isGitHubError(error)) {
-      throw new Error(formatGitHubError(error));
-    }
-    throw error;
+const errorHandler = (error: unknown) => {
+  if (error instanceof z.ZodError) {
+    throw new Error(`Invalid input: ${JSON.stringify(error.errors)}`);
   }
+  if (isGitHubError(error)) {
+    throw new Error(formatGitHubError(error as GitHubError));
+  }
+  throw error;
+};
+
+const server = new McpServer({
+  name: "github-actions-mcp-server",
+  version: VERSION,
+}, {
+  capabilities: {
+    tools: {},
+  },
 });
+
+type ListWorkflowsParams = z.infer<typeof actions.ListWorkflowsSchema>;
+type GetWorkflowParams = z.infer<typeof actions.GetWorkflowSchema>;
+type GetWorkflowUsageParams = z.infer<typeof actions.GetWorkflowUsageSchema>;
+type ListWorkflowRunsParams = z.infer<typeof actions.ListWorkflowRunsSchema>;
+type GetWorkflowRunParams = z.infer<typeof actions.GetWorkflowRunSchema>;
+type GetWorkflowRunJobsParams = z.infer<typeof actions.GetWorkflowRunJobsSchema>;
+type TriggerWorkflowParams = z.infer<typeof actions.TriggerWorkflowSchema>;
+type CancelWorkflowRunParams = z.infer<typeof actions.CancelWorkflowRunSchema>;
+type RerunWorkflowParams = z.infer<typeof actions.RerunWorkflowSchema>;
+
+server.tool(
+  "list_workflows",
+  "List workflows in a GitHub repository",
+  actions.ListWorkflowsSchema.shape,
+  async (params: ListWorkflowsParams) => {
+    try {
+      const result = await actions.listWorkflows(
+        params.owner,
+        params.repo,
+        params.page,
+        params.perPage
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "get_workflow",
+  "Get details of a specific workflow",
+  actions.GetWorkflowSchema.shape,
+  async (params: GetWorkflowParams) => {
+    try {
+      const result = await actions.getWorkflow(
+        params.owner,
+        params.repo,
+        params.workflowId
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "get_workflow_usage",
+  "Get usage statistics of a workflow",
+  actions.GetWorkflowUsageSchema.shape,
+  async (params: GetWorkflowUsageParams) => {
+    try {
+      const result = await actions.getWorkflowUsage(
+        params.owner,
+        params.repo,
+        params.workflowId
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "list_workflow_runs",
+  "List all workflow runs for a repository or a specific workflow",
+  actions.ListWorkflowRunsSchema.shape,
+  async (params: ListWorkflowRunsParams) => {
+    try {
+      const { owner, repo, workflowId, ...options } = params;
+      const result = await actions.listWorkflowRuns(owner, repo, {
+        workflowId,
+        ...options
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "get_workflow_run",
+  "Get details of a specific workflow run",
+  actions.GetWorkflowRunSchema.shape,
+  async (params: GetWorkflowRunParams) => {
+    try {
+      const result = await actions.getWorkflowRun(
+        params.owner,
+        params.repo,
+        params.runId
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "get_workflow_run_jobs",
+  "Get details of a specific workflow run",
+  actions.GetWorkflowRunJobsSchema.shape,
+  async (params: GetWorkflowRunJobsParams) => {
+    try {
+      const { owner, repo, runId, filter, page, perPage } = params;
+      const result = await actions.getWorkflowRunJobs(
+        owner,
+        repo,
+        runId,
+        filter,
+        page,
+        perPage
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "trigger_workflow",
+  "Trigger a workflow run",
+  actions.TriggerWorkflowSchema.shape,
+  async (params: TriggerWorkflowParams) => {
+    try {
+      const { owner, repo, workflowId, ref, inputs } = params;
+      const result = await actions.triggerWorkflow(
+        owner,
+        repo,
+        workflowId,
+        ref,
+        inputs
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "cancel_workflow_run",
+  "Cancel a workflow run",
+  actions.CancelWorkflowRunSchema.shape,
+  async (params: CancelWorkflowRunParams) => {
+    try {
+      const result = await actions.cancelWorkflowRun(
+        params.owner,
+        params.repo,
+        params.runId
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
+
+server.tool(
+  "rerun_workflow",
+  "Re-run a workflow run",
+  actions.RerunWorkflowSchema.shape,
+  async (params: RerunWorkflowParams) => {
+    try {
+      const result = await actions.rerunWorkflowRun(
+        params.owner,
+        params.repo,
+        params.runId
+      );
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (error) {
+      errorHandler(error);
+      return { content: [{ type: "text", text: "Error" }] };
+    }
+  },
+);
 
 async function runServer() {
   const transport = new StdioServerTransport();


### PR DESCRIPTION
This pull request updates the @modelcontextprotocol/sdk dependency from 1.10.1 to 1.10.2 and refactors the server initialization and related imports in src/index.ts accordingly.

- Bump @modelcontextprotocol/sdk to 1.10.2 in package.json and package-lock.json
- Refactor server initialization to use McpServer and update related imports
- Remove unused imports and clean up error handling

No changes to .gitignore are included in this PR.